### PR TITLE
Add #5 SpringBatch 테스트 (Costomize Highlighting 최고레벨 설정으로인한 혼란.)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,9 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.batch:spring-batch-test'
     implementation 'mysql:mysql-connector-java'
+
+    // h2 데이터베이스
+    testRuntimeOnly 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,3 +35,13 @@ spring:
     jdbc:
       # SpringBatch schema 생성유무
       initialize-schema: ALWAYS
+
+---
+spring:
+  config:
+    activate:
+      # 테스트 환경일때의 설정
+      on-profile: test
+  jpa:
+    # 테스트일때에는 h2 데이터베이스 사용
+    database: h2

--- a/src/test/java/com/springbatch/hellospringbatch/BatchTestConfig.java
+++ b/src/test/java/com/springbatch/hellospringbatch/BatchTestConfig.java
@@ -1,0 +1,17 @@
+package com.springbatch.hellospringbatch;
+
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+// @EnableBatchProcessing 스프링 배치를 실행하기 위한 설정
+@EnableBatchProcessing
+// @EnableAutoConfiguration 설정파일이다. 스프링 부트의 meta 파일을 읽어서,
+// 미리 정의되어 있는 자바 설정 파일들을 빈으로 등록하는 역할을 수행한다.
+// META-INF / spring.factories 에 있는 많은 설정들을 읽어들인다.
+@EnableAutoConfiguration
+public class BatchTestConfig {
+
+}
+

--- a/src/test/java/com/springbatch/hellospringbatch/job/HelloJobConfigTest.java
+++ b/src/test/java/com/springbatch/hellospringbatch/job/HelloJobConfigTest.java
@@ -1,0 +1,46 @@
+package com.springbatch.hellospringbatch.job;
+
+import com.springbatch.hellospringbatch.BatchTestConfig;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.test.JobLauncherTestUtils;
+import org.springframework.batch.test.context.SpringBatchTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+// @SpringBatchTest: 사용시 Batch Test 에서 사용할 수 있는 유용한 스프링 빈을 등록해준다.
+@SpringBatchTest
+// @SpringBootTest: 실제 애플리케이션을 자신의 로컬 위에 올려서 포트 주소가 Listening 되고, 실제 Database 와 커넥션이 붙는 상태에서 진행되는 Live 테스트 방법
+// @WebMvcTest: Controller 레이어만을 테스트하기에 적합한 테스트 어노테이션으로 전체 애플리케이션 실행이 아닌 Controller 만들 로드하여 테스트가능(소규모 테스트)
+@SpringBootTest
+// @ExtendWith: 단위 테스트간에 공통적으로 사용할 기능을 구현하여 @ExtendWith 를 통하여 적용할 수 있는 기능을 제공한다.
+// SpringExtension 은 Spring TestContext 프레임워크를 JUnit 5의 Jupiter 프로그래밍 모델에 통합합니다.
+@ExtendWith(SpringExtension.class)
+// application.yml 에 설정한 test 설정을 여기에 입혀준다. h2database 사용
+@ActiveProfiles("test")
+// 스프링 컨텍스트 설정파일을 읽어들인다. 여기서는 HelloJobConfig, BatchTestConfig 를 읽어온다.
+@ContextConfiguration(classes = {HelloJobConfig.class, BatchTestConfig.class})
+public class HelloJobConfigTest {
+
+    // JobLauncherTestUtils: 스프링 배치 테스트에 필요한 유틸 기능
+    @Autowired
+    private JobLauncherTestUtils jobLauncherTestUtils;
+    @Test
+    public void success() throws Exception {
+        // When
+        JobExecution execution = jobLauncherTestUtils.launchJob();
+
+        // Then
+        assertEquals(execution.getExitStatus(), ExitStatus.COMPLETED);
+    }
+
+}

--- a/src/text/Ch03.SpringBatch 기본 프로젝트/04.SpringBatch 테스트
+++ b/src/text/Ch03.SpringBatch 기본 프로젝트/04.SpringBatch 테스트
@@ -1,0 +1,34 @@
+
+    * SpringBatch 테스트
+      1.H2
+      2.@SpringBatchTest - JobLauncherTestUtils
+
+
+    * 설정
+      1.build.gradle 에 H2 데이터베이스를 넣어준다.
+      2.application.yml 파일에 test 환경일때의 설정을 넣어주고
+        test 시에는 h2 데이터 베이스를 사용한다고 명시한다.
+      3.test 폴더 밑에 BatchTestConfig 클래스를 생성한다.
+      - @SpringBatchTest: 사용시 Batch Test 에서 사용할 수 있는 유용한 스프링 빈을 등록해준다.
+      - @SpringBootTest: 실제 애플리케이션을 자신의 로컬 위에 올려서 포트 주소가 Listening 되고, 실제 Database 와 커넥션이 붙는 상태에서 진행되는 Live 테스트 방법
+      - @WebMvcTest: Controller 레이어만을 테스트하기에 적합한 테스트 어노테이션으로 전체 애플리케이션 실행이 아닌 Controller 만들 로드하여 테스트가능(소규모 테스트)
+      - @ExtendWith(SpringExtension.class): 단위 테스트간에 공통적으로 사용할 기능을 구현하여 @ExtendWith 를 통하여 적용할 수 있는 기능을 제공한다.
+      - SpringExtension 은 Spring TestContext 프레임워크를 JUnit 5의 Jupiter 프로그래밍 모델에 통합합니다.
+      - @ActiveProfiles("test"): application.yml 에 설정한 test 설정을 여기에 입혀준다. h2database 사용
+      - @ContextConfiguration(classes = {HelloJobConfig.class, BatchTestConfig.class}): 스프링 컨텍스트 설정파일을 읽어들인다.
+
+      4.JobLauncherTestUtils 에 대한 잠깐의 설명
+        1.Test시에는 필요한 Job을 설정해주어야 한다.
+        2.JobLauncherTestUtils 내부에 setJob() 메서드가 있다.
+        3.@SpringBootTest를 통해 JobLauncherTestUtils가 오토와이어링 될때에
+        4.setJob()을 이용해 Job을 자동으로 와이어링 해준다. (빈 간의 의존성을 자동으로 만족시켜줬다.)
+        5.JobConfig가 여러개라면 어떤 Job을 와이어링 해주는가?
+        6.@ContextConfiguration(classes = {HelloJobConfig.class, BatchTestConfig.class}): 스프링 컨텍스트 설정파일을 읽어들인다.
+          을 통해서 HelloJobConfig.class 로 설정해준다. 만약 이걸 설정해주지 않을시에는
+          JobConfig 설정이 여러개 되어있다면 애러가 난다. 꼭 하나를 지정해주자.
+
+
+        * 오토와이어링이란?
+        오토와이어링은 스프링이 빈의 요구 사항과 매칭되는 애플리케이션 컨텍스트상에서 다른 빈을 찾아 빈 간의 의존성을 자동으로 만족시키는 수단이다.
+        오토와이어링 수행을 하도록 지정하기 위해서는 @Autowired 애너 테이션을 사용한다.
+


### PR DESCRIPTION
IntelliJ의 Costomize Highlighting 설정을 가장 높게 해두는 바람에 JobLauncherTestUtils가 계속 빨간 줄이 떳다.  Could not autowire. No beans of 'JobLauncherTestUtils' type found. 오류 내용으로는 빈을 찾을수 없다고 표기하기에BatchTestConfig에 직접 Bean 등록을 하고 실행했더니 빈 중복이라는 오류가 나왔다.

그래서 한참 해메다가 커스텀 하이라이트를 꺼주니 빨간줄이 사라졌다...... 억울하다.